### PR TITLE
feat:patch bolt "utc" support in Bolt 4.4

### DIFF
--- a/lib/src/client_config.c
+++ b/lib/src/client_config.c
@@ -76,10 +76,10 @@ const struct neo4j_plan_table_colors *neo4j_plan_table_ansi_colors =
         &_neo4j_plan_table_ansi_colors;
 
 static version_spec_t neo4j_supported_versions[4] = {
-  {5, 0, 0}, {4, 0, 0}, {3, 0, 0}, {1, 0, 0}
+  {5, 0, 0}, {4, 4, 0}, {3, 0, 0}, {1, 0, 0}
 };
 
-static const char neo4j_supported_versions_string[] = "5.0,4.0,3.0,1.0";
+static const char neo4j_supported_versions_string[] = "5.0,4.4,3.0,1.0";
 
 static ssize_t default_password_callback(void *userdata, char *buf, size_t n);
 

--- a/lib/src/connection.c
+++ b/lib/src/connection.c
@@ -457,8 +457,8 @@ int negotiate_protocol_version(neo4j_iostream_t *iostream,
         return -1;
     }
     agreed_version = ntohl(agreed_version);
-    *protocol_version = agreed_version & 0007;
-    *protocol_minor_version = (agreed_version & 0700) >> 8;
+    *protocol_version = agreed_version & 0x0007;
+    *protocol_minor_version = (agreed_version & 0x0700) >> 8;
     return 0;
 }
 

--- a/lib/src/connection.c
+++ b/lib/src/connection.c
@@ -1232,6 +1232,19 @@ int initialize(neo4j_connection_t *connection)
       req->argv = req->_argv;
       req->argc = 2;
       }
+    else if (connection->version == 4 && connection->minor_version == 4)
+      {
+        neo4j_value_t patch_bolt[1] = {neo4j_string("utc")};
+        neo4j_map_entry_t auth_token[5] =
+          { neo4j_map_entry("user_agent", neo4j_string(config->client_id)),
+            neo4j_map_entry("scheme", neo4j_string("basic")),
+            neo4j_map_entry("principal", neo4j_string(config->username)),
+            neo4j_map_entry("credentials", neo4j_string(config->password)),
+            neo4j_map_entry("patch_bolt", neo4j_list(patch_bolt, 1)) };
+        req->_argv[0] = neo4j_map(auth_token, 5);
+        req->argv = req->_argv;
+        req->argc = 1;
+      }
     else
       {
         neo4j_map_entry_t auth_token[4] =

--- a/lib/src/connection.c
+++ b/lib/src/connection.c
@@ -319,8 +319,8 @@ neo4j_connection_t *establish_connection(const char *hostname,
 
     neo4j_log_info(logger, "connected (%p) to %s:%u%s", (void *)connection,
             hostname, port, connection->insecure? " (insecure)" : "");
-    neo4j_log_debug(logger, "connection %p using protocol version %d",
-            (void *)connection, protocol_version);
+    neo4j_log_debug(logger, "connection %p using protocol version %d.%d",
+            (void *)connection, protocol_version, protocol_minor_version);
     neo4j_atomic_bool_set(&(connection->poison_tx),false);
     return connection;
 

--- a/lib/test/check_config.c
+++ b/lib/test/check_config.c
@@ -33,7 +33,7 @@ START_TEST (test_neo4j_config_set_supported_versions)
   neo4j_config_t *config = neo4j_new_config();
   ck_assert(config->supported_versions != NULL);
   ck_assert_str_eq
-    (neo4j_config_get_supported_versions(config), "5.0 4.0 3.0 1.0 "); // default
+    (neo4j_config_get_supported_versions(config), "5.0 4.4 3.0 1.0 "); // default
   ck_assert_int_eq
     (neo4j_config_set_supported_versions(config, "5.4"),0);
   ck_assert_int_eq
@@ -73,7 +73,7 @@ START_TEST (test_neo4j_config_set_supported_versions)
   ck_assert_int_eq
     (neo4j_config_set_supported_versions(config, "5.4,4.3-4,3,crap"),-1);
   ck_assert_str_eq
-    (neo4j_config_get_supported_versions(config), "5.0 4.0 3.0 1.0 "); // default
+    (neo4j_config_get_supported_versions(config), "5.0 4.4 3.0 1.0 "); // default
   
 
   

--- a/lib/test/check_connection.c
+++ b/lib/test/check_connection.c
@@ -30,7 +30,7 @@ struct received_response
 
 
 #define EXPECTED_VERSIONS_DEFAULT \
-    { htonl(0x000005), htonl(0x000004), htonl(0x000003), htonl(0x000001) }
+    { htonl(0x000005), htonl(0x000404), htonl(0x000003), htonl(0x000001) }
 
 #define STUB_FAILURE_CODE -99
 


### PR DESCRIPTION
1. Fix a bug of getting minor version. The original impl incorrectly used octal mask rather than hexadecimal, resulting in always getting a wrong minor version.
2. Use "utc" `patch bolt` in bolt version 4.4. Resolves #22 
3. Bump the default 4.x version from 4.0 to 4.4.