### PR TITLE
Fix some memory Leak about transactions, loggers, strdups

### DIFF
--- a/lib/src/client_config.c
+++ b/lib/src/client_config.c
@@ -724,6 +724,7 @@ int neo4j_config_set_supported_versions(neo4j_config_t *config, const char *vers
 	  // set default
 	  neo4j_config_set_supported_versions(config, neo4j_supported_versions_string);
 	  fprintf(stderr, "%s\n", neo4j_config_get_supported_versions(config));
+      free(vs);
 	  return -1;
 	}
       p = strtok(NULL, ",");
@@ -735,6 +736,7 @@ int neo4j_config_set_supported_versions(neo4j_config_t *config, const char *vers
     (config->supported_versions+n)->and_lower = 0;
     n++;
   }
+  free(vs);
   return 0;
 }
 

--- a/lib/src/neo4j-client.h.in
+++ b/lib/src/neo4j-client.h.in
@@ -295,6 +295,14 @@ struct neo4j_logger_provider
  *
  * If no flags are required, pass 0 or `NEO4J_STD_LOGGER_DEFAULT`.
  *
+ * @warning **Thread-Safety Warning:** The logger provider instance returned by
+ * this function is **NOT thread-safe**.
+ *
+ * It is unsafe to share a single `neo4j_config_t` object containing this
+ * provider across multiple threads if those threads will be creating
+ * connections (`neo4j_connect` or `neo4j_tcp_connect`) concurrently. Doing so may
+ * lead to race conditions, memory corruption or memory leak.
+ *
  * @param [stream] The stream to output to.
  * @param [level] The default level to log at.
  * @param [flags] A bitmask of flags for the standard logger output.

--- a/lib/src/tofu.c
+++ b/lib/src/tofu.c
@@ -42,10 +42,10 @@ int neo4j_check_known_hosts(const char * restrict hostname, int port,
         const char * restrict fingerprint, const neo4j_config_t *config,
         uint_fast8_t flags)
 {
+    REQUIRE(strlen(hostname) < 256 && hostname[0] != '\0', -1);
+
     int result = -1;
     neo4j_logger_t *logger = neo4j_get_logger(config, "tofu");
-
-    REQUIRE(strlen(hostname) < 256 && hostname[0] != '\0', -1);
 
     char *buf = NULL;
     const char *file = config->known_hosts_file;

--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -375,7 +375,7 @@ neo4j_transaction_t *new_transaction(neo4j_config_t *config, neo4j_connection_t 
   tx->run = tx_run;
 
   tx->timeout = timeout;
-  tx->mode = ( mode == NULL ? "w" : strdup(mode) );
+  tx->mode = ( (mode == NULL || strcmp(mode, "r")) ? "w" : "r" );
   tx->dbname = strdup(dbname);
   tx->is_open = 0;
   tx->is_expired = 0;
@@ -535,6 +535,7 @@ void neo4j_free_tx(neo4j_transaction_t *tx)
   if (tx->num_bookmarks > 0) {
     neo4j_free(tx->allocator, (void *)tx->bookmarks);
   }
+  free(tx->dbname);
   neo4j_mpool_drain(&tx->mpool);
   neo4j_logger_release(tx->logger);
   // free tx space

--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -532,9 +532,10 @@ const char *neo4j_tx_commit_bookmark(neo4j_transaction_t *tx)
 void neo4j_free_tx(neo4j_transaction_t *tx)
 {
   // free bookmarks array space
-  // free tx space
   if (tx->num_bookmarks > 0) {
     neo4j_free(tx->allocator, (void *)tx->bookmarks);
   }
+  neo4j_logger_release(tx->logger);
+  // free tx space
   neo4j_free(tx->allocator, tx);
 }

--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -535,6 +535,7 @@ void neo4j_free_tx(neo4j_transaction_t *tx)
   if (tx->num_bookmarks > 0) {
     neo4j_free(tx->allocator, (void *)tx->bookmarks);
   }
+  neo4j_mpool_drain(&tx->mpool);
   neo4j_logger_release(tx->logger);
   // free tx space
   neo4j_free(tx->allocator, tx);

--- a/lib/src/transaction.h
+++ b/lib/src/transaction.h
@@ -69,7 +69,7 @@ struct neo4j_transaction
   neo4j_value_t extra; // client-side message arguments
   int timeout; // client-side timeout in ms requested
   const char *mode; // client-side mode string : "w" write, "r" read
-  const char *dbname; // client-side database name string (Bolt 4+)
+  char *dbname; // client-side database name string (Bolt 4+)
   neo4j_value_t failure_code; // server-side failure code (neo4j_string)
   neo4j_value_t failure_message; // server-side failure message (neo4j_string)
 };


### PR DESCRIPTION
1. In `new_transaction`, the resources it allocated were all not released in `neo4j_free_tx`, including the unreleased logger, undrained mpool and unfree strdup.
2. The strdup issue in `new_transaction` is more complicated, because the ownership of the memory for `tx->mode` is very ambiguous. I try to change this to be only static "w" or static "r". If the input `mode` is not equal to "r", then `tx->mode` will be default "w".
3. The `tx->dbname` in transaction is also a problem. If it would free, the dbname must be defined as `char *` rather than `const char *`. Considering the transaction owns the dbanme, it should hold the string to be not const since the transaction should take responsibility to free it.
4. Another unfree strdup is found in `neo4j_config_set_supported_versions`.
5. In `neo4j_check_known_hosts`, the `REQUIRED` macro add a concealed return point without the `neo4j_logger_release`. The macro must be used at the beginning of a function.
6. The std logger provider is not multithread safe. I think it is easy to be misused, so I add some documentations.