### PR TITLE
Allow build on GCC 4.8 and earlier

### DIFF
--- a/lib/src/connection.c
+++ b/lib/src/connection.c
@@ -34,6 +34,10 @@
 #include <assert.h>
 #include <unistd.h>
 
+#ifndef __has_attribute
+#  define __has_attribute(x) 0  /* for GCC 4.8 and earlier */
+#endif
+
 static int add_userinfo_to_config(const char *userinfo, neo4j_config_t *config,
         uint_fast32_t flags);
 static neo4j_connection_t *establish_connection(const char *hostname,


### PR DESCRIPTION
We’ve seen a smoke report of a build failure involving `__has_attribute()`, added in #13. The compiler used on the machine in question was identified as “GCC 4.8.5 20150623 (Red Hat 4.8.5-44.0.3)”.

https://matrix.perl-magpie.org/results/0a46c170-b936-11f0-808a-fb452148c370

The GCC documentation has some notes on the correct use of `__has_attribute()`. In particular, portable code must expect it to be undefined.

https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html

I’m not sure if we want to actually offer real support for compiler versions this old. But at the very least, getting rid of the false positive in smoke testing is probably worth making this change.