### PR TITLE
Fix segfault on drain_queued_requests

### DIFF
--- a/lib/src/connection.c
+++ b/lib/src/connection.c
@@ -1101,7 +1101,7 @@ int drain_queued_requests(neo4j_connection_t *connection)
         neo4j_log_trace(connection->logger, "draining %s (%p) from queue on %p",
                 neo4j_message_type_str(request->type),
                 (void *)request, (void *)connection);
-        int result = request->receive(request->cdata, NULL, NULL, 0);
+        int result = request->receive(request->cdata, NEO4J_IGNORED_MESSAGE, NULL, 0);
         assert(result <= 0);
         if (err == 0 && result < 0)
         {

--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -114,9 +114,6 @@ int begin_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_t *
       neo4j_log_trace(tx->logger, "tx begin ignored");
       return 0;
     }
-  char description[128];
-  snprintf(description, sizeof(description), "%s in %p (response to BEGIN)",
-           neo4j_message_type_str(type), (void *)tx->connection);
 
 #ifndef NEOCLIENT_BUILD  
   if (type != NEO4J_SUCCESS_MESSAGE)
@@ -124,6 +121,9 @@ int begin_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_t *
   if ( !MESSAGE_TYPE_IS(type,SUCCESS) )
 #endif
     {
+      char description[128];
+      snprintf(description, sizeof(description), "%s in %p (response to BEGIN)",
+               neo4j_message_type_str(type), (void *)tx->connection);
       neo4j_log_error(tx->logger, "Unexpected %s", description);
       tx->failed = 1;
       tx->failure = EPROTO;
@@ -185,9 +185,6 @@ int commit_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_t 
       neo4j_log_trace(tx->logger, "tx commit ignored");
       return 0;
     }
-  char description[128];
-  snprintf(description, sizeof(description), "%s in %p (response to COMMIT)",
-           neo4j_message_type_str(type), (void *)tx->connection);
 
 #ifndef NEOCLIENT_BUILD  
   if (type != NEO4J_SUCCESS_MESSAGE)
@@ -195,6 +192,9 @@ int commit_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_t 
   if ( !MESSAGE_TYPE_IS(type,SUCCESS) )
 #endif
     {
+      char description[128];
+      snprintf(description, sizeof(description), "%s in %p (response to COMMIT)",
+               neo4j_message_type_str(type), (void *)tx->connection);
       neo4j_log_error(tx->logger, "Unexpected %s", description);
       tx->failed = -1;
       tx->failure = EPROTO;
@@ -263,9 +263,6 @@ int rollback_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_
       neo4j_log_trace(tx->logger, "tx rollback ignored");
       return 0;
     }
-  char description[128];
-  snprintf(description, sizeof(description), "%s in %p (response to ROLLBACK)",
-           neo4j_message_type_str(type), (void *)tx->connection);
 
 #ifndef NEOCLIENT_BUILD  
   if (type != NEO4J_SUCCESS_MESSAGE)
@@ -273,6 +270,9 @@ int rollback_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_
   if ( !MESSAGE_TYPE_IS(type,SUCCESS) )
 #endif
     {
+      char description[128];
+      snprintf(description, sizeof(description), "%s in %p (response to ROLLBACK)",
+               neo4j_message_type_str(type), (void *)tx->connection);
       neo4j_log_error(tx->logger, "Unexpected %s", description);
       tx->failed = 1;
       fprintf(stderr,"Unexpected %s", description);

--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -84,6 +84,7 @@ neo4j_transaction_t *neo4j_begin_tx(neo4j_connection_t *connection,
 int begin_callback(void *cdata, neo4j_message_type_t type, const neo4j_value_t *argv, uint16_t argc)
 {
   assert(cdata != NULL);
+  assert(type != NULL);
   assert(argc == 0 || argv != NULL);
   neo4j_transaction_t *tx = (neo4j_transaction_t *) cdata;
 


### PR DESCRIPTION
Fix a segmentation fault caused by drain_queued_requests. 

Also, optimized some functions inside transaction.c, to avoid formatting messages if they are not used.